### PR TITLE
Update sysfs_backlight for MBP11,1 screen brightness

### DIFF
--- a/pommed/sysfs_backlight.c
+++ b/pommed/sysfs_backlight.c
@@ -94,6 +94,7 @@ static char *brightness[] =
     "/sys/class/backlight/nvidia_backlight/brightness",
     "/sys/class/backlight/nv_backlight/brightness",
     "/sys/class/backlight/acpi_video0/brightness",
+    "/sys/class/backlight/intel_backlight/brightness",
 #endif
   };
 
@@ -114,6 +115,7 @@ static char *max_brightness[] =
     "/sys/class/backlight/nvidia_backlight/max_brightness",
     "/sys/class/backlight/nv_backlight/max_brightness",
     "/sys/class/backlight/acpi_video0/max_brightness",
+    "/sys/class/backlight/intel_backlight/max_brightness",
 #endif
   };
 

--- a/pommed/sysfs_backlight.c
+++ b/pommed/sysfs_backlight.c
@@ -73,6 +73,7 @@ static char *actual_brightness[] =
     "/sys/class/backlight/nvidia_backlight/actual_brightness",
     "/sys/class/backlight/nv_backlight/actual_brightness",
     "/sys/class/backlight/acpi_video0/actual_brightness",
+    "/sys/class/backlight/intel_backlight/actual_brightness",
 #endif
   };
 


### PR DESCRIPTION
My MacBookPro11,1 uses /sys/class/backlight/intel_backlight/actual_brightness.
Without the mod I get: 
`
➜  pommed git:(master) sudo ./pommed -d
I: pommed v1.40git Apple laptops hotkeys handler
I: Copyright (C) 2006-2011 Julien BLACHE jb@jblache.org
pommed configuration:
- General settings:
  fnmode: 1
- sysfs backlight control:
  initial level: -1
  step: 1
  on_batt: 6
- ATI X1600 backlight control:
  initial level: -1
  step: 10
  on_batt: 80
- Intel GMA950 backlight control:
  initial level: 0xffffffff
  step: 0xf
  on_batt: 0x40
- nVidia GeForce 8600M GT backlight control:
  initial level: -1
  step: 1
  on_batt: 6
- Audio volume control:
  card: default
  initial volume: -1
  step: 10%
  beep: yes
  volume element: PCM
  speaker element: Front
  headphones element: Headphone
- Keyboard backlight control:
  default level: 100
  step: 10
  auto on threshold: 20
  auto off threshold: 40
  auto enable: yes
  idle timer: 60s
  idle level: 0
- CD eject:
  enabled: yes
  device: /dev/dvd
- Beep:
  enabled: no
  beepfile: /usr/share/pommed/goutte.wav
- Apple Remote IR Receiver:
  enabled: no

DMI vendor name: [Apple Inc.]

DMI product name: [MacBookPro11,1]

I: DMI machine check: running on a MacBookPro11,1

System: Linux 4.5.4-1-ARCH x86_64

Failed to access brightness node: No such file or directory

Failed to access brightness node: No such file or directory

Failed to access brightness node: No such file or directory

Failed to access brightness node: No such file or directory

Failed to access brightness node: No such file or directory

Failed to access brightness node: No such file or directory

E: sysfs backlight probe failed, no fallback for this machine

E: LCD backlight probe failed, check debug output
`
